### PR TITLE
Add schema for use in v2 and v3

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -18,3 +18,5 @@ apimlServices:
     - file: sample-node-api.yml
 configs:
   port: 18000
+schemas:
+  configs: trivial-schema.json

--- a/trivial-schema.json
+++ b/trivial-schema.json
@@ -1,0 +1,21 @@
+{  
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://abcdef.com/schemas/v2/sample-node-api",
+  "allOf": [
+    { "$ref": "https://zowe.org/schemas/v2/server-base" },
+    { 
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {  
+            "sample-iframe": {
+              "$ref": "https://zowe.org/schemas/v2/server-base#zoweComponent"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This extension is missing a schema, making it invalid according to v2 and v3 documentation.
It is otherwise compatible, and is referenced in documentation tutorials, so updating this.
Afterwards, I recommend archiving this as it appears unmaintained.